### PR TITLE
[MERGE]: dev-branch into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore all generated artifacts including compiled binaries, build intermediates,
+# debug outputs (disassembly, symbols, ELF analysis), and generated documentation.
+
+# NOTE: the artifacts are provided in their respective release tags, checkout 
+#       https://github.com/serene-brew/Neutron/releases to download them.
+
+bin/
+docs/
+build/
+debug/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,14 +134,14 @@ graph TD
   - `main.c` — Entry point `neutron_main()`: UART init + banner, mailbox (board revision, ARM memory), board identification, then either:
     - **SD/FAT32 path** (`embed-kernel = false`): SD init, FAT32 mount, read `CFG_KERNEL_FILENAME` into staging (`CFG_KERNEL_STAGING_ADDR`), validate NKRN, `bl_load_kernel()`
     - **Embedded path** (`embed-kernel = true`): use the linked-in packed kernel image, validate NKRN, `bl_load_kernel()`
-    - then fill mailbox fields in `boot_info_t`, countdown, `bl_boot_kernel(entry, &boot_info)`
-  - `bootloader.c` — `bl_load_kernel(src, out_info)`: validate NKRN magic, version, size, CRC32 of payload; copy payload to header.load_addr; write `boot_info_t` at BOOT_INFO_ADDR (0x1000); `bl_boot_kernel(entry_addr, info)`: dsb/isb, call kernel with x0 = info
+    - then fill mailbox fields in `boot_info_t`, countdown, `bl_boot_kernel(uintptr_t entry, boot_info_t *info, uintptr_t dtb_addr)`
+  - `bootloader.c` — `bl_load_kernel(src, out_info)`: validate NKRN magic, version, size, CRC32 of payload; copy payload to header.load_addr; write `boot_info_t` at BOOT_INFO_ADDR (0x1000) and dtb_addr at x1 reg; `bl_boot_kernel(uintptr_t entry, boot_info_t *info, uintptr_t dtb_addr)`: dsb/isb, call kernel with x0 = info, x1 = dtb_addr
 - **Key Responsibilities**:
   1. Bring up UART and print system/boot info
   2. Get board and memory info via mailbox
   3. Initialise SD card and mount first FAT32 partition
   4. Load packed kernel into staging (or use embedded image), validate NKRN, copy payload to load address (0x200000), fill boot_info at 0x1000
-  5. Jump to kernel entry with x0 = pointer to boot_info_t
+  5. Jump to kernel entry with x0 = pointer to boot_info_t and x1 = DTB address
 
 ---
 
@@ -174,7 +174,7 @@ flowchart TD
     READ_SD --> VALIDATE{NKRN valid?}
     VALIDATE -->|No| HALT([Halt])
     VALIDATE -->|Yes| LOAD["neutron/bootloader.c<br/>- bl_load_kernel<br/>- CRC32, copy to 0x200000<br/>- Fill boot_info at 0x1000"]
-    LOAD --> JUMP["bl_boot_kernel<br/>- x0 = boot_info*<br/>- Jump to 0x200000"]
+    LOAD --> JUMP["bl_boot_kernel<br/>- x0 = boot_info*<br/>- x1 = dtb_addr<br/>- Jump to 0x200000"]
     JUMP --> KERNEL["test_kernel<br/>- kernel_start.S → kernel_main<br/>- Print boot_info, heartbeat"]
     KERNEL --> RUN([Kernel running])
 ```
@@ -241,7 +241,7 @@ graph LR
 - **0x00000000 – 0x3EFFFFFF**: RAM (1 GiB on raspi3b)
 - **0x80000**: Bootloader load address (`kernel8.img`). Stack grows downward from here.
 - **0x100000**: Kernel staging (SD path). The file named by `kernel_filename` is read from SD into this region; bootloader parses the NKRN header here and copies payload to the load address.
-- **0x200000**: Kernel load and entry address. The NKRN payload is copied here; bootloader jumps to this address with x0 = boot_info*.
+- **0x200000**: Kernel load and entry address. The NKRN payload is copied here; bootloader jumps to this address with x0 = boot_info* and x1 = dtb_addr.
 - **0x1000**: `boot_info_t` structure filled by the bootloader (magic, board_revision, arm_mem_size, kernel_load_addr, kernel_entry_addr, kernel_size, bootloader_version string).
 - **0x3F000000**: BCM2837 peripheral base (MMIO).
 - **0x3F200000**: GPIO.
@@ -279,7 +279,7 @@ graph LR
 |-----------|----------|-----------------|
 | **CPU / EL** | `boot/start.S` | Park secondaries, EL2→EL1, MMU/cache off, stack, BSS, call neutron_main |
 | **Bootloader entry** | `neutron/main.c` | UART, banner, mailbox, then either embedded-kernel path or SD+FAT32 load of `kernel_filename`, NKRN check, bl_load_kernel, bl_boot_kernel |
-| **Kernel load** | `neutron/bootloader.c` | NKRN validation, CRC32, copy payload to load_addr, fill boot_info at 0x1000, jump with x0 = boot_info |
+| **Kernel load** | `neutron/bootloader.c` | NKRN validation, CRC32, copy payload to load_addr, fill boot_info at 0x1000, jump with x0 = boot_info and x1=dtb_addr |
 | **UART** | `driver/uart.c` | PL011 at 0x3F201000, GPIO 14/15 ALT0, 115200 8N1 |
 | **GPIO** | `driver/gpio.c` | Function select, pull-up/down for UART pins |
 | **Mailbox** | `driver/mbox.c` | Board revision, ARM memory size |

--- a/Makefile
+++ b/Makefile
@@ -504,6 +504,7 @@ clean-debug:
 clean:
 	@rm -rf $(BUILD_DIR)/*
 	@rm -rf $(BIN_DIR)/*
+	@rm -rf debug/*
 	@echo "Clean done."
 
 # ----------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ QEMU_FLAGS  := -machine $(QEMU_MACHINE) \
 # ----------------------------------------------------------------
 # Phony targets
 # ----------------------------------------------------------------
-.PHONY: all bootloader kernel sd-image clean \
+.PHONY: all bootloader kernel sd-image clean debug clean-debug \
         qemu-rpi qemu-rpi-debug disasm size help \
         check-tools check-cross-tools check-python check-sd-tools check-qemu
 
@@ -410,6 +410,95 @@ size: $(BL_ELF) $(K_RAW_ELF)
 	@$(SIZE) -A $(K_RAW_ELF)
 
 # ----------------------------------------------------------------
+# Debug
+# ----------------------------------------------------------------
+debug: CFLAGS += -g -O0 -DDEBUG
+debug: $(BL_ELF) $(K_RAW_ELF)
+	@mkdir -p debug/linkermap debug/drivers debug/bootloader debug/kernel debug/symbols debug/disasm debug/elf
+
+	@echo "=== Generating Debug Artifacts ==="
+	@echo ""
+
+	@echo "[DBG] Bootloader artifacts..."
+	@cp $(BL_ELF) debug/elf/neutron.elf
+	@echo "    => $(OBJDUMP) -d -S -l $(BL_ELF) > debug/disasm/neutron.disasm"
+	@$(OBJDUMP) -d -S -l $(BL_ELF) > debug/disasm/neutron.disasm
+	@echo "    => $(CROSS)readelf --debug-dump=info $(BL_ELF) > debug/elf/neutron.elf.info"
+	@$(CROSS)readelf --debug-dump=info $(BL_ELF) > debug/elf/neutron.elf.info
+	@echo "    => $(CROSS)readelf -a $(BL_ELF) > debug/elf/neutron.elf.full"
+	@$(CROSS)readelf -a $(BL_ELF) > debug/elf/neutron.elf.full
+	@echo "   [OK] Bootloader ELF + disassembly + debug info"
+	@echo ""
+
+	@echo "[DBG] Linker maps..."
+	@test -f build/neutron.map && cp build/neutron.map debug/linkermap/ || true
+	@test -f build/kernel.map && cp build/kernel.map debug/linkermap/ || true
+	@echo "   [OK] Maps: neutron.map, kernel.map"
+	@echo ""
+
+	@echo "[DBG] Driver disassembly (per-module)..."
+	@for drivsrc in $(DRIVER_DIR)/*.c; do \
+	    drivname=$$(basename $$drivsrc .c); \
+	    drivobj=$(BUILD_DIR)/$$(dirname $$drivsrc)/$$(basename $$drivsrc .c).o; \
+	    if [ -f $$drivobj ]; then \
+	        $(OBJDUMP) -d -S -l $$drivobj > debug/drivers/$${drivname}.dis; \
+	        echo "   [OK] $$drivname.dis"; \
+	    fi; \
+	done
+	@echo ""
+
+	@echo "[DBG] Kernel artifacts..."
+	@cp $(K_RAW_ELF) debug/elf/kernel.elf
+	@echo "    => $(OBJDUMP) -d -S -l $(K_RAW_ELF) > debug/disasm/kernel.disasm"
+	@$(OBJDUMP) -d -S -l $(K_RAW_ELF) > debug/disasm/kernel.disasm
+	@echo "    => $(CROSS)readelf --debug-dump=info $(K_RAW_ELF) > debug/elf/kernel.elf.info"
+	@$(CROSS)readelf --debug-dump=info $(K_RAW_ELF) > debug/elf/kernel.elf.info
+	@echo "    => $(CROSS)readelf -a $(K_RAW_ELF) > debug/elf/kernel.elf.full"
+	@$(CROSS)readelf -a $(K_RAW_ELF) > debug/elf/kernel.elf.full
+	@echo "   [OK] Kernel ELF + disassembly + debug info"
+	@echo ""
+
+	@echo "[DBG] Symbol tables..."
+	@echo "    => $(CROSS)nm -C -l -n -S $(BL_ELF) > debug/symbols/neutron.symbols"
+	@$(CROSS)nm -C -l -n -S $(BL_ELF) > debug/symbols/neutron.symbols
+	@echo "    => $(CROSS)nm -C -l -n -S $(K_RAW_ELF) > debug/symbols/kernel.symbols"
+	@$(CROSS)nm -C -l -n -S $(K_RAW_ELF) > debug/symbols/kernel.symbols
+	@echo "   [OK] Symbol tables with line info"
+	@echo ""
+
+	@echo "[DBG] Size analysis..."
+	@echo "    => $(SIZE) -A $(BL_ELF) > debug/bootloader/size"
+	@$(SIZE) -A $(BL_ELF) > debug/bootloader/size
+	@echo "    => $(SIZE) -A $(K_RAW_ELF) > debug/kernel/size"
+	@$(SIZE) -A $(K_RAW_ELF) > debug/kernel/size
+	@echo "   [OK] Section size summaries"
+	@echo ""
+
+	@echo "[DBG] Binary info..."
+	@echo "    => $(OBJDUMP) -f $(BL_ELF) > debug/bootloader/info"
+	@$(OBJDUMP) -f $(BL_ELF) > debug/bootloader/info
+	@echo "    => $(OBJDUMP) -f $(K_RAW_ELF) > debug/kernel/info"
+	@$(OBJDUMP) -f $(K_RAW_ELF) > debug/kernel/info
+	@echo "   [OK] Entry points & binary information"
+	@echo ""
+
+	@echo "[DBG] Build manifest..."
+	@echo "Build Date   : $$(date)" > debug/DEBUG_MANIFEST.txt
+	@echo "Build Type   : Debug" >> debug/DEBUG_MANIFEST.txt
+	@echo "Flags        : -O0 -g -DDEBUG" >> debug/DEBUG_MANIFEST.txt
+	@echo "Configuration:" >> debug/DEBUG_MANIFEST.txt
+	@cat build.cfg >> debug/DEBUG_MANIFEST.txt
+	@echo "" >> debug/DEBUG_MANIFEST.txt
+	@echo "=== Debug Directory Structure ===" >> debug/DEBUG_MANIFEST.txt
+	@tree -L 2 debug/ >> debug/DEBUG_MANIFEST.txt 2>/dev/null || find debug -type f | sort >> debug/DEBUG_MANIFEST.txt
+	@echo "   [OK] Manifest with config snapshot"
+	@echo ""
+	@echo "=== Debug Build Complete ==="
+
+clean-debug:
+	rm -rf debug/*
+
+# ----------------------------------------------------------------
 # Clean
 # ----------------------------------------------------------------
 clean:
@@ -430,6 +519,8 @@ help:
 		@echo "  make sd-image         Create sd.img FAT32 disk with $(KERNEL_FILENAME)"
 		@echo "  make qemu-rpi         Boot in QEMU (SD card path)"
 		@echo "  make size             Section sizes for both"
+		@echo "  make debug            Generate debug artifacts (disasm, symbols, maps, etc.)"
+		@echo "  make clean-debug      Remove debug directory"
 		@echo "  make clean            Remove all build artefacts"
 		@echo ""
 		@echo "External kernel options:"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img width="500" height="500" alt="Neutron_Logo_for_Github" src="https://github.com/user-attachments/assets/8b634af5-5973-4994-9cdc-d485141269e3" />
 
 ### A Piece of Project atom
-### v1.1.4
+### v1.3.0
 </div>
 
 ---
@@ -27,7 +27,7 @@ Neutron is a minimal yet functional bootloader that:
 - Initializes the SD card and mounts the first FAT32 partition
 - Loads a packed kernel image (**ATOM.BIN**) from the SD card into a staging area at **0x100000**
 - Validates the NKRN header (magic, CRC32), copies the payload to the load address (**0x200000**), and fills a `boot_info_t` at **0x1000**
-- Jumps to the kernel entry point with `x0` = pointer to `boot_info_t`
+- Jumps to the kernel entry point with `x0` = pointer to `boot_info_t` and `x1` = DTB address
 - Provides debug output throughout execution
 
 Designed for educational purposes, QEMU simulation (`-machine raspi3b`), and deployment on Raspberry Pi Zero 2W (or Pi 3B) with an SD card.
@@ -75,11 +75,13 @@ aarch64-none-elf-gcc --version
 ### Building
 
 ```bash
-make clean
-make all        # build bootloader + kernel (+ sd.img unless embed-kernel = true)
-make bootloader # compile only kernel8.img
-make kernel     # compile only atom.bin (raw kernel + NKRN pack)
-make sd-image   # create sd.img (FAT32; kernel filename from build.cfg)
+make clean              # remove build artifacts
+make all                # build bootloader + kernel (+ sd.img unless embed-kernel = true)
+make bootloader         # compile only kernel8.img
+make kernel             # compile only atom.bin (raw kernel + NKRN pack)
+make sd-image           # create sd.img (FAT32; kernel filename from build.cfg)
+make debug              # generate debug artifacts (disasm, symbols, maps, etc.) with -O0 -g -DDEBUG
+make clean-debug        # remove debug directory
 ```
 
 Build behaviour depends on **`build.cfg`**: the kernel filename (e.g. `ATOM.BIN` or `CUSTOM.BIN`) and **`embed-kernel`** (if `true`, the kernel is embedded in `kernel8.img` and no SD image is built by default). This generates:
@@ -134,7 +136,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation. For build-tim
 |-----------|------|
 | **boot/start.S** | CPU init, exception level drop (EL2→EL1), park secondaries, BSS zero, call `neutron_main` |
 | **neutron/main.c** | UART init, banner, mailbox (board rev / ARM mem), SD init, FAT32 mount, load ATOM.BIN, validate NKRN, `bl_load_kernel`, `bl_boot_kernel` |
-| **neutron/bootloader.c** | NKRN validation, CRC32 check, copy payload to load address, fill `boot_info_t` at 0x1000, `bl_boot_kernel` (jump with x0 = boot_info) |
+| **neutron/bootloader.c** | NKRN validation, CRC32 check, copy payload to load address, fill `boot_info_t` at 0x1000, `bl_boot_kernel` (jump with x0 = boot_info, x1 = dtb_addr) |
 | **driver/uart.c** | PL011 UART at 0x3F201000 (GPIO 14/15 ALT0), 115200 8N1 |
 | **driver/gpio.c** | BCM2837 GPIO (function select, pull-up/down) |
 | **driver/mbox.c** | VideoCore mailbox (board revision, ARM memory size) |

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-VERSION: v1.1.4
+VERSION: v1.3.0
 AUTHOR: SERENE BREW
 SOURCE: https://github.com/serene-brew/Neutron.git
 TOOL: NEUTRON

--- a/boot/start.S
+++ b/boot/start.S
@@ -61,6 +61,10 @@ _from_el2:
  * _el1_entry  -  running at EL1, finish CPU init
  * ---------------------------------------------------------------- */
 _el1_entry:
+    /* ---- Save DTB address (passed by ARM firmware in x0) ---- */
+    /* Use callee-saved register x19 to preserve DTB across bl call */
+    mov     x19, x0
+
     /* ---- Disable MMU / caches at EL1 (safe defaults) ---- */
     mrs     x0, sctlr_el1
     bic     x0, x0, #(1 << 0)     // M   = 0  disable MMU
@@ -83,6 +87,9 @@ _bss_loop:
     cmp     x0, x1
     blt     _bss_loop
 _bss_done:
+
+    /* ---- Pass DTB address to neutron_main in x0 ---- */
+    mov     x0, x19
 
     /* ---- Jump to C bootloader entry ---- */
     bl      neutron_main

--- a/build.cfg
+++ b/build.cfg
@@ -30,10 +30,10 @@ log_level = quiet
 ansi_colors = true
 
 # Banner line shown at boot (string)
-banner_text = "Neutron Bootloader  v1.1.4"
+banner_text = "Neutron Bootloader  v1.3.0"
 
 # Bootloader version string written into boot_info_t (max 15 chars + NUL)
-bootloader_version = "Neutron-1.1.4"
+bootloader_version = "Neutron-1.3.0"
 
 # Kernel version string packed into the NKRN header and written into boot_info_t
 # Format: "vMAJOR.MINOR"  (e.g. "v1.0", "v2.3")

--- a/internal/bootloader.h
+++ b/internal/bootloader.h
@@ -71,11 +71,13 @@ int bl_load_kernel(uintptr_t src, boot_info_t *out_info);
 
 /*
  * bl_boot_kernel()
- *   Jump to entry_addr with boot_info_t * in x0.
+ *   Jump to entry_addr with boot_info_t * in x0 and DTB address in x1.
+ *   Custom ABI for custom kernels: x0 = boot_info_t*, x1 = DTB address.
  *   Does NOT return.
  */
 void __attribute__((noreturn)) bl_boot_kernel(uintptr_t entry_addr,
-                                              boot_info_t *info);
+                                              boot_info_t *info,
+                                              uintptr_t dtb_addr);
 
 /* CRC32 helper (IEEE 802.3 polynomial) */
 uint32_t crc32(const uint8_t *data, size_t len);

--- a/internal/config.h
+++ b/internal/config.h
@@ -8,8 +8,8 @@
 #define CFG_KERNEL_MAX_SIZE      0x400000UL
 #define CFG_LOG_LEVEL            0
 #define CFG_ANSI_COLORS         1
-#define CFG_BANNER_TEXT         "Neutron Bootloader  v1.1.4"
-#define CFG_BOOTLOADER_VERSION  "Neutron-1.1.4"
+#define CFG_BANNER_TEXT         "Neutron Bootloader  v1.3.0"
+#define CFG_BOOTLOADER_VERSION  "Neutron-1.3.0"
 #define CFG_KERNEL_VERSION      "v1.0"
 #define CFG_KERNEL_VERSION_MAJOR 1
 #define CFG_KERNEL_VERSION_MINOR 0

--- a/neutron.ps1
+++ b/neutron.ps1
@@ -203,13 +203,14 @@ try {
         }
         
         switch ($Target) {
-            "all"        { }
-            "bootloader" { }
-            "kernel"     { }
-            "sd-image"   { }
-            "clean"      { }
-            "size"       { }
-            "debug"      { }
+            "all"         { }
+            "bootloader"  { }
+            "kernel"      { }
+            "sd-image"    { }
+            "clean"       { }
+            "clean-debug" { }
+            "size"        { }
+            "debug"       { }
             
             default {
                 Write-Error "Invalid build target: '$Target'"
@@ -220,6 +221,7 @@ try {
                 Write-Host "  kernel"
                 Write-Host "  sd-image"
                 Write-Host "  clean"
+                Write-Host "  clean-debug"
                 Write-Host "  size"
                 Write-Host "  debug"
                 exit 1
@@ -401,7 +403,8 @@ try {
         Write-Host "    bootloader        Build kernel8.img only"
         Write-Host "    kernel            Build packed test kernel (outputs bin/atom.bin)"
         Write-Host "    sd-image          Create sd.img only"
-        Write-Host "    clean             Remove build artifacts"
+        Write-Host "    clean             Remove build and debug artifacts"
+        Write-Host "    clean-debug       Remove debug artifacts"
         Write-Host "    size              Show section sizes"
         Write-Host "    debug             Generate debug artifacts (disasm, symbols, maps, etc.)"
         Write-Host ""

--- a/neutron.ps1
+++ b/neutron.ps1
@@ -5,6 +5,7 @@
 # 
 # Organization : serene brew
 # Author       : TriDEntApollO
+# Co-Author    : mintRaven-05
 # License      : BSD-3-Clause
 #
 # ================================================================
@@ -208,6 +209,7 @@ try {
             "sd-image"   { }
             "clean"      { }
             "size"       { }
+            "debug"      { }
             
             default {
                 Write-Error "Invalid build target: '$Target'"
@@ -219,6 +221,7 @@ try {
                 Write-Host "  sd-image"
                 Write-Host "  clean"
                 Write-Host "  size"
+                Write-Host "  debug"
                 exit 1
             }
         }
@@ -400,6 +403,7 @@ try {
         Write-Host "    sd-image          Create sd.img only"
         Write-Host "    clean             Remove build artifacts"
         Write-Host "    size              Show section sizes"
+        Write-Host "    debug             Generate debug artifacts (disasm, symbols, maps, etc.)"
         Write-Host ""
         Write-Host "  Options:"
         Write-Host "    --kernel <path>          Use a prebuilt packed NKRN kernel (skips test_kernel build)"

--- a/neutron.sh
+++ b/neutron.sh
@@ -2,6 +2,11 @@
 # =============================================================================
 # Neutron Bootloader - Project Atom
 # neutron  - Linux/macOS build & run orchestration
+#
+# Organization : serene brew
+# Author       : mintRaven-05
+# License      : BSD-3-Clause
+#
 # =============================================================================
 
 set -e
@@ -212,7 +217,7 @@ neutron_build() {
   MakeArgs=("${ParsedArgs[@]:1}")
 
   case "$Target" in
-  all | bootloader | kernel | sd-image | clean | size) ;;
+  all | bootloader | kernel | sd-image | clean | size | debug) ;;
   *)
     echo "Invalid build target: '$Target'"
     echo
@@ -223,6 +228,7 @@ neutron_build() {
     echo "  sd-image"
     echo "  clean"
     echo "  size"
+    echo "  debug"
     exit 1
     ;;
   esac
@@ -389,6 +395,7 @@ show_help() {
   echo "    sd-image              Create sd.img only"
   echo "    clean                 Remove build artifacts"
   echo "    size                  Show section sizes"
+  echo "    debug                 Generate debug artifacts (disasm, symbols, maps, etc.)"
   echo
   echo "  Options:"
   echo "    --kernel <path>       Use a prebuilt packed NKRN kernel (skips test_kernel build)"

--- a/neutron.sh
+++ b/neutron.sh
@@ -217,7 +217,7 @@ neutron_build() {
   MakeArgs=("${ParsedArgs[@]:1}")
 
   case "$Target" in
-  all | bootloader | kernel | sd-image | clean | size | debug) ;;
+  all | bootloader | kernel | sd-image | clean | size | debug | clean-debug) ;;
   *)
     echo "Invalid build target: '$Target'"
     echo
@@ -227,6 +227,7 @@ neutron_build() {
     echo "  kernel"
     echo "  sd-image"
     echo "  clean"
+    echo "  clean-debug"
     echo "  size"
     echo "  debug"
     exit 1
@@ -393,7 +394,8 @@ show_help() {
   echo "    bootloader            Build kernel8.img only"
   echo "    kernel                Build packed test kernel (outputs bin/atom.bin)"
   echo "    sd-image              Create sd.img only"
-  echo "    clean                 Remove build artifacts"
+  echo "    clean                 Remove build and debug artifacts"
+  echo "    clean-debug           Remove only debug artifacts"
   echo "    size                  Show section sizes"
   echo "    debug                 Generate debug artifacts (disasm, symbols, maps, etc.)"
   echo

--- a/neutron/bootloader.c
+++ b/neutron/bootloader.c
@@ -188,7 +188,7 @@ int bl_load_kernel(uintptr_t src, boot_info_t *out_info) {
   uart_printf("[BL] Kernel version : %s\n", info->kernel_version);
 
   if (out_info)
-    bl_memcpy(out_info, info, sizeof(*info));
+    *out_info = *info;  // Copy to output if caller wants a reference copy
 
   return BL_OK;
 }
@@ -196,20 +196,29 @@ int bl_load_kernel(uintptr_t src, boot_info_t *out_info) {
 /* ----------------------------------------------------------------
  * bl_boot_kernel()
  *   Flush caches (ISB/DSB), then jump.
- *   Convention: x0 = pointer to boot_info_t
+ *   Convention: x0 = boot_info_t*, x1 = DTB address
  * ---------------------------------------------------------------- */
 void __attribute__((noreturn)) bl_boot_kernel(uintptr_t entry_addr,
-                                              boot_info_t *info) {
+                                              boot_info_t *info,
+                                              uintptr_t dtb_addr) {
   uart_printf("[BL] Jumping to kernel at %p\n", (void *)entry_addr);
+  uart_printf("[BL] boot_info at x0: %p\n", (void *)info);
+  uart_printf("[BL] DTB address in x1: %p\n", (void *)dtb_addr);
 
   /* Ensure all writes are visible before the jump */
   __asm__ volatile("dsb sy\n"
                    "isb\n" ::
                        : "memory");
 
-  /* Call kernel: x0 = boot_info_t * */
-  void (*kernel_entry)(boot_info_t *) = (void (*)(boot_info_t *))entry_addr;
-  kernel_entry(info);
+  /* Call kernel with custom ABI: x0 = boot_info_t*, x1 = DTB address */
+  __asm__ volatile(
+    "mov x0, %0\n"        // x0 = boot_info_t*
+    "mov x1, %1\n"       // x1 = DTB address
+    "br %2\n"            // branch to kernel entry
+    :
+    : "r"(info), "r"(dtb_addr), "r"(entry_addr)
+    : "x0", "x1", "memory"
+  );
 
   /* Should never reach here */
   while (1)

--- a/neutron/main.c
+++ b/neutron/main.c
@@ -69,11 +69,13 @@ static uint64_t read_mpidr(void) {
 
 /* ----------------------------------------------------------------
  * neutron_main()  -  called from start.S
+ *   Receives DTB address from ARM firmware (passed via x0)
  * ---------------------------------------------------------------- */
-void neutron_main(void) {
+void neutron_main(uintptr_t dtb_addr) {
   /* ----- Hardware init ----- */
   uart_init();
   print_banner();
+  uart_printf("[BL] DTB address: %p\n", (void *)dtb_addr);
 
   /* ----- CPU state ----- */
   uint32_t el = read_exception_level();
@@ -176,8 +178,7 @@ void neutron_main(void) {
   /* ----- Run bootloader validation + copy ----- */
   uart_puts("\n[BL] Validating and loading kernel image...\n");
 
-  boot_info_t boot_info;
-  rc = bl_load_kernel(nkrn_src, &boot_info);
+  rc = bl_load_kernel(nkrn_src, NULL);
 
   if (rc != BL_OK) {
     uart_printf(CFG_ANSI_RED
@@ -188,21 +189,24 @@ void neutron_main(void) {
       __asm__ volatile("wfe");
   }
 
+  /* Get boot_info from well-known address 0x1000 */
+  boot_info_t *boot_info = (boot_info_t *)(uintptr_t)BOOT_INFO_ADDR;
+
   /* Fill in mailbox-obtained fields */
-  boot_info.board_revision = board_rev;
-  boot_info.arm_mem_size = arm_mem;
+  boot_info->board_revision = board_rev;
+  boot_info->arm_mem_size = arm_mem;
 
   /* ----- Boot countdown ----- */
   uart_puts("\n[BL] Kernel loaded successfully.\n");
   uart_printf("[BL] Entry point : %p\n",
-              (void *)(uintptr_t)boot_info.kernel_entry_addr);
+              (void *)(uintptr_t)boot_info->kernel_entry_addr);
 
   for (int i = 3; i > 0; i--) {
     for (volatile uint32_t d = 0; d < 2000000U; d++)
       __asm__ volatile("nop");
   }
 
-  bl_boot_kernel((uintptr_t)boot_info.kernel_entry_addr, &boot_info);
+  bl_boot_kernel((uintptr_t)boot_info->kernel_entry_addr, boot_info, dtb_addr);
 
   __builtin_unreachable();
 }


### PR DESCRIPTION
## Description
Porting neutron into new minor update version v1.3.0
In this update, neutron takes the DTB address and stores it in `x19` (`callee-saved-general-purpose register`) temporarily for saving context between function calls. Once done, move the value back from `x19` to `x0`.
Pass the DTB address from `x0` to `x1` for kernel to access and then fill the `boot_info_t` struct.
Update the Makefile and introduce `debug` and `clean-debug` phony for generating debug artifacts (bootloader and driver disassembly, section tables, linkermaps, etc.) and add the following targets in `neutron.sh` and `neutron.ps1`

new phony usage: 
- `make debug` (this generates the bin and elf files if not present and then generates debug artifacts)
- `make clean-debug` (this only removes the `Neutron/debug` artifacts and not the `Neutron/build` and `Neutron/bin` artifacts)

> [!NOTE]
> `make clean` now also removes the `Neutron/debug` artifacts along with `Neutron/build` and `Neutron/bin` artifacts by default

## Related Issue
Closes #8

## Target Branch
main

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation update

## Testing
- [x] QEMU

## Checklist
- [x] Code builds successfully
- [x] No warnings introduced
- [x] Documentation updated (if required)

## Changelog
- **[UPDATE]: pass DTB address, preserve it at `x19` callee-saved-gen-purpose and move back to x0 after bl_calls**
- **[UPDATE]: pass the DTB address pointer as arg to kernel**
- **[UPDATE]: use the new `bl_boot_kernel` with `dtb_addr` arg and log the DTB addr**
- **[UPDATE]: move the DTB addr from x0 to x1 for kernel access**
- **[ADD]: .gitignore for build and debug artifacts**
- **[BUILD]: add `debug` and `clean-debug` phony to generate disassembly, linkermaps and symbol table of the drivers, neutron and the test_kernel**
- **[BUILD]: add `debug` target for `build` in powershell script**
- **[BUILD]: add `debug` target to linux/macOS build script**
- **[FIX/BUILD]: remove debug artifacts in `make clean`**
- **[FIX/BUILD]: add `clean-debug` target for cleaning only debug artifacts in powershell script**
- **[FIX/BUILD]: add `clean-debug` target for cleaning debug artifacts in linux/macOS build script**
- **[DOCS]: update `bl_boot_kernel()` parameters and document about `x1=dtb_addr`**
- **[DOCS]: update version and `bl_boot_kernel()` parameters**
- **[UPDATE]: port to latest VERSION tag v1.3.0**
